### PR TITLE
Read only topicmap stores cause leaking connections in combination with concurrency

### DIFF
--- a/ontopia-engine/src/main/java/net/ontopia/topicmaps/impl/rdbms/RDBMSTopicMapStore.java
+++ b/ontopia-engine/src/main/java/net/ontopia/topicmaps/impl/rdbms/RDBMSTopicMapStore.java
@@ -319,6 +319,15 @@ public class RDBMSTopicMapStore extends AbstractTopicMapStore {
 
   public void close(boolean returnStore) {
     if (returnStore) {
+
+      // allow access to release connection, preventing loads of idle connections
+      if ((transaction != null) && transaction.isActive()) {
+        TransactionIF tnx = transaction.getTransaction();
+        if (tnx.isActive()) {
+          ((RDBMSAccess)tnx.getStorageAccess()).releaseConnection();
+        }
+      }
+
       // return store
       if (reference != null) {
         


### PR DESCRIPTION
- The `RDBMSAccess.conn_map` field is a Map with a Thread key, which can be replaced by a ThreadLocal. This causes unneeded memory leaking until GC'ed. Applying a ThreadLocal also removes the need for some synchronization blocks.
- The `RDBMSTopicMapStore.close` method does not return the used connection to the connection pool. This becomes a problem when there are more TopicMapReferences accessed then their are available connections to the database. This can be solved by returning the RO store connection to the pool until it is needed again.

Note that concurrent use of a TopicMapStore can still cause leaking connections!
